### PR TITLE
feat: Read Kinvey keys from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "~5.2.0",
     "@angular/platform-browser-dynamic": "~5.2.0",
     "@angular/router": "~5.2.0",
-    "kinvey-nativescript-sdk": "^3.9.10",
+    "kinvey-nativescript-sdk": "3.10.1-beta.0",
     "nativescript-angular": "~5.2.0",
     "nativescript-theme-core": "~1.0.4",
     "reflect-metadata": "~0.1.10",
@@ -49,11 +49,11 @@
     "typescript": "~2.6.2"
   },
   "pluginsData": {
-      "kinvey-nativescript-sdk": {
-          "config": {
-              "appKey": "",
-              "appSecret": ""
-          }
+    "kinvey-nativescript-sdk": {
+      "config": {
+        "appKey": "",
+        "appSecret": ""
       }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,5 +47,13 @@
     "nativescript-dev-typescript": "~0.6.0",
     "nativescript-dev-webpack": "~0.9.1",
     "typescript": "~2.6.2"
+  },
+  "pluginsData": {
+      "kinvey-nativescript-sdk": {
+          "config": {
+              "appKey": "",
+              "appSecret": ""
+          }
+      }
   }
 }

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -1,4 +1,0 @@
-export class Config {
-    static kinveyAppKey = "KINVEY_APP_KEY";
-    static kinveyAppSecret = "KINVEY_APP_SECRET";
-}

--- a/shared/kinvey.common.ts
+++ b/shared/kinvey.common.ts
@@ -1,5 +1,4 @@
 import { Kinvey } from "kinvey-nativescript-sdk";
-import { Config } from "./config";
 
 /* ***********************************************************
 * The {N} Kinvey plugin initialization is explained in the plugin readme here:
@@ -8,7 +7,4 @@ import { Config } from "./config";
 * You can build and run this template without creating your own Kinvey project.
 *************************************************************/
 
-Kinvey.init({
-    appKey: Config.kinveyAppKey,
-    appSecret: Config.kinveyAppSecret
-});
+Kinvey.init();

--- a/tools/kinvey/kinvey-setup.md
+++ b/tools/kinvey/kinvey-setup.md
@@ -3,10 +3,14 @@ NOTE: This guide assumes that you have a working version of the Enterprise Auth 
 
 ### Modify the app to use your Kinvey project
 
- - In Kinvey go to your app dashboard (you can find your app key and secret in the dropdown menu in the environment sidebar), copy both the **App Key** and **App Secret** then replace them in `app/shared/config.ts`. For example if your App Key is **kid_Sy8CV9v7W** with App Secret **94d5019e0f45412b9dc419f94e019ca0**, the updated config.ts will look like:
-```typescript
-export class Config {
-    static kinveyAppKey = "kid_Sy8CV9v7W";
-    static kinveyAppSecret = "94d5019e0f45412b9dc419f94e019ca0";
+ - In Kinvey go to your app dashboard (you can find your app key and secret in the dropdown menu in the environment sidebar), copy both the **App Key** and **App Secret** then replace them in `app/package.json`. For example if your App Key is **kid_Sy8CV9v7W** with App Secret **94d5019e0f45412b9dc419f94e019ca0**, the updated pluginsData in package.json will look like:
+```JSON
+"pluginsData": {
+    "kinvey-nativescript-sdk": {
+        "config": {
+            "appKey": "kid_Sy8CV9v7W",
+            "appSecret": "94d5019e0f45412b9dc419f94e019ca0"
+        }
+    }
 }
 ```


### PR DESCRIPTION
The new version of kinvey-nativescript-sdk allows calling `Kinvey.init()` without arguments. The plugin reads the data from app/package.json internally and uses the values for appSecret and appKey.
So remove the config.ts file and add instructions how to set the data in package.json. Predefine empty values for the keys, so when the template is installed in Sidekick, we will be able to determine that the plugin configuration is not correct and prompt the user to create Kinvey app.