### PR TITLE
chore: remove AoT helper files

### DIFF
--- a/app/app.module.ngfactory.d.ts
+++ b/app/app.module.ngfactory.d.ts
@@ -1,4 +1,0 @@
-/**
- * A dynamically generated module when compiled with AoT.
- */
-export const AppModuleNgFactory: any;

--- a/app/main.aot.ts
+++ b/app/main.aot.ts
@@ -1,8 +1,0 @@
-// this import should be first in order to load some required settings (like globals and reflect-metadata)
-import { platformNativeScript } from "nativescript-angular/platform-static";
-
-import { AppModuleNgFactory } from "./app.module.ngfactory";
-
-import "./shared/kinvey.common";
-
-platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "nativescript-dev-typescript": "~0.7.0",
-    "nativescript-dev-webpack": "~0.15.0",
+    "nativescript-dev-webpack": "rc",
     "typescript": "~2.8.2"
   }
 }


### PR DESCRIPTION
They won't be needed with {N}-dev-webpack 0.16.0, because of this change
- https://github.com/NativeScript/nativescript-dev-webpack/pull/634.